### PR TITLE
Create Auto2510_Ignore.cfg

### DIFF
--- a/Auto2510_Ignore.cfg
+++ b/Auto2510_Ignore.cfg
@@ -1,0 +1,11 @@
+; J9019B IGNORE Configuration Editor; Created on release #RA.15.17.0008
+hostname "ADP-IN-PROGRESS"
+include-credentials
+password manager user-name ${telnet_user_name} plaintext ${telnet_password}
+snmp-server community ${snmpv1_community_read} operator
+snmp-server community ${snmpv1_community_write} unrestricted
+vlan 1
+   name "DEFAULT_VLAN"
+   untagged all
+   ip address dhcp-bootp
+   exit


### PR DESCRIPTION
Initial Config configured to work with J9019B 2510-24 switch, with Ignore flag so also compatible with 2530, and 2620 models... Should work for any AOSS device that supports the "Generic Header ID in cofig file" feature.
